### PR TITLE
Fix http500 when creating patron with an existing email

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiosmtplib==4.0.0
 amqp==5.3.1
 annotated-types==0.7.0
 anyio==4.8.0
+bcrypt==4.0.1
 billiard==4.2.1
 celery==5.4.0
 certifi==2025.1.31


### PR DESCRIPTION
Update the **create_patron** endpoint to check if the incoming email already exists in the database, 
if it already exists return HTTP 409 (Conflict) with a clear error message 

Related endpoint: /patrons/
Method: POST 

Closes https://github.com/ibrahimceyisakar/library-management-system/issues/5